### PR TITLE
- Delete robot namespace in launch file

### DIFF
--- a/launch/simple_system_monitor.launch
+++ b/launch/simple_system_monitor.launch
@@ -3,17 +3,14 @@
 
 	<!-- Desired frequency -->
 	<arg name="desired_freq" default="1" />
+	
+	<!-- Load SimpleSystemMonitor configuration -->
+	<arg name="simple_system_monitor_config_path" default="$(find simple_system_monitor)/config/simple_system_monitor_config.yaml" />
+	<rosparam file="$(arg simple_system_monitor_config_path)" command="load" />
 
-	<group ns="robot">
-		<!-- Load SimpleSystemMonitor configuration -->
-		<arg name="simple_system_monitor_config_path" default="$(find simple_system_monitor)/config/simple_system_monitor_config.yaml" />
-		<rosparam file="$(arg simple_system_monitor_config_path)" command="load" />
-
-		<!-- Start simple_system_monitor node -->
-		<node pkg="simple_system_monitor" name="simple_system_monitor" type="simple_system_monitor_node.py" output="screen">
-			<param name="desired_freq" value="$(arg desired_freq)"/>
-		</node>
-	</group>
-
+	<!-- Start simple_system_monitor node -->
+	<node pkg="simple_system_monitor" name="simple_system_monitor" type="simple_system_monitor_node.py" output="screen">
+		<param name="desired_freq" value="$(arg desired_freq)"/>
+	</node>
 
 </launch>


### PR DESCRIPTION
This pull request includes changes to the `launch/simple_system_monitor.launch` file to simplify the launch configuration by removing an unnecessary group tag.

* Simplified launch configuration by removing the redundant `<group>` tag around the `simple_system_monitor` node and its parameters. [[1]](diffhunk://#diff-4be96be20f129a9ea8e2c799f727f2c43aff06a9dcde1da7bfc68ed389fadc7fL7) [[2]](diffhunk://#diff-4be96be20f129a9ea8e2c799f727f2c43aff06a9dcde1da7bfc68ed389fadc7fL16-L17)